### PR TITLE
set up better commits

### DIFF
--- a/.better-commits.json
+++ b/.better-commits.json
@@ -1,0 +1,161 @@
+{
+	"check_status": true,
+	"commit_type": {
+		"enable": true,
+		"initial_value": "feat",
+		"infer_type_from_branch": true,
+		"append_emoji_to_label": false,
+		"append_emoji_to_commit": false,
+		"options": [
+			{
+				"value": "feat",
+				"label": "feat",
+				"hint": "A new feature",
+				"emoji": "✨",
+				"trailer": "Changelog: feature"
+			},
+			{
+				"value": "fix",
+				"label": "fix",
+				"hint": "A bug fix",
+				"emoji": "🐛",
+				"trailer": "Changelog: fix"
+			},
+			{
+				"value": "docs",
+				"label": "docs",
+				"hint": "Documentation only changes",
+				"emoji": "📚",
+				"trailer": "Changelog: documentation"
+			},
+			{
+				"value": "refactor",
+				"label": "refactor",
+				"hint": "A code change that neither fixes a bug nor adds a feature",
+				"emoji": "🔨",
+				"trailer": "Changelog: refactor"
+			},
+			{
+				"value": "perf",
+				"label": "perf",
+				"hint": "A code change that improves performance",
+				"emoji": "🚀",
+				"trailer": "Changelog: performance"
+			},
+			{
+				"value": "test",
+				"label": "test",
+				"hint": "Adding missing tests or correcting existing tests",
+				"emoji": "🚨",
+				"trailer": "Changelog: test"
+			},
+			{
+				"value": "build",
+				"label": "build",
+				"hint": "Changes that affect the build system or external dependencies",
+				"emoji": "🚧",
+				"trailer": "Changelog: build"
+			},
+			{
+				"value": "ci",
+				"label": "ci",
+				"hint": "Changes to our CI configuration files and scripts",
+				"emoji": "🤖",
+				"trailer": "Changelog: ci"
+			},
+			{
+				"value": "tool",
+				"label": "tool",
+				"hint": "Changes to tooling",
+				"emoji": "🔧",
+				"trailer": "Changelog: tool"
+			},
+			{
+				"value": "chore",
+				"label": "chore",
+				"hint": "Other changes that do not modify src or test files",
+				"emoji": "🧹",
+				"trailer": "Changelog: chore"
+			},
+			{
+				"value": "",
+				"label": "none"
+			}
+		]
+	},
+	"commit_scope": {
+		"enable": true,
+		"custom_scope": false,
+		"initial_value": "website",
+		"options": [
+			{
+				"value": "website",
+				"label": "website"
+			},
+			{
+				"value": "tools",
+				"label": "tools"
+			},
+			{
+				"value": "",
+				"label": "none"
+			}
+		]
+	},
+	"check_ticket": {
+		"infer_ticket": true,
+		"confirm_ticket": true,
+		"add_to_title": true,
+		"append_hashtag": false,
+		"surround": "",
+		"title_position": "start"
+	},
+	"commit_title": {
+		"max_size": 70
+	},
+	"commit_body": {
+		"enable": true,
+		"required": false
+	},
+	"commit_footer": {
+		"enable": true,
+		"initial_value": [],
+		"options": ["closes", "trailer", "breaking-change", "deprecated", "custom"]
+	},
+	"breaking_change": {
+		"add_exclamation_to_title": true
+	},
+	"confirm_commit": true,
+	"print_commit_output": true,
+	"branch_pre_commands": [],
+	"branch_post_commands": [],
+	"worktree_pre_commands": [],
+	"worktree_post_commands": [],
+	"branch_user": {
+		"enable": true,
+		"required": false,
+		"separator": "/"
+	},
+	"branch_type": {
+		"enable": true,
+		"separator": "/"
+	},
+	"branch_version": {
+		"enable": false,
+		"required": false,
+		"separator": "/"
+	},
+	"branch_ticket": {
+		"enable": true,
+		"required": false,
+		"separator": "-"
+	},
+	"branch_description": {
+		"max_length": 70,
+		"separator": ""
+	},
+	"branch_action_default": "branch",
+	"branch_order": ["user", "version", "type", "ticket", "description"],
+	"enable_worktrees": true,
+	"overrides": {}
+}

--- a/.better-commits.json
+++ b/.better-commits.json
@@ -1,161 +1,161 @@
 {
-	"check_status": true,
-	"commit_type": {
-		"enable": true,
-		"initial_value": "feat",
-		"infer_type_from_branch": true,
-		"append_emoji_to_label": false,
-		"append_emoji_to_commit": false,
-		"options": [
-			{
-				"value": "feat",
-				"label": "feat",
-				"hint": "A new feature",
-				"emoji": "✨",
-				"trailer": "Changelog: feature"
-			},
-			{
-				"value": "fix",
-				"label": "fix",
-				"hint": "A bug fix",
-				"emoji": "🐛",
-				"trailer": "Changelog: fix"
-			},
-			{
-				"value": "docs",
-				"label": "docs",
-				"hint": "Documentation only changes",
-				"emoji": "📚",
-				"trailer": "Changelog: documentation"
-			},
-			{
-				"value": "refactor",
-				"label": "refactor",
-				"hint": "A code change that neither fixes a bug nor adds a feature",
-				"emoji": "🔨",
-				"trailer": "Changelog: refactor"
-			},
-			{
-				"value": "perf",
-				"label": "perf",
-				"hint": "A code change that improves performance",
-				"emoji": "🚀",
-				"trailer": "Changelog: performance"
-			},
-			{
-				"value": "test",
-				"label": "test",
-				"hint": "Adding missing tests or correcting existing tests",
-				"emoji": "🚨",
-				"trailer": "Changelog: test"
-			},
-			{
-				"value": "build",
-				"label": "build",
-				"hint": "Changes that affect the build system or external dependencies",
-				"emoji": "🚧",
-				"trailer": "Changelog: build"
-			},
-			{
-				"value": "ci",
-				"label": "ci",
-				"hint": "Changes to our CI configuration files and scripts",
-				"emoji": "🤖",
-				"trailer": "Changelog: ci"
-			},
-			{
-				"value": "tool",
-				"label": "tool",
-				"hint": "Changes to tooling",
-				"emoji": "🔧",
-				"trailer": "Changelog: tool"
-			},
-			{
-				"value": "chore",
-				"label": "chore",
-				"hint": "Other changes that do not modify src or test files",
-				"emoji": "🧹",
-				"trailer": "Changelog: chore"
-			},
-			{
-				"value": "",
-				"label": "none"
-			}
-		]
-	},
-	"commit_scope": {
-		"enable": true,
-		"custom_scope": false,
-		"initial_value": "website",
-		"options": [
-			{
-				"value": "website",
-				"label": "website"
-			},
-			{
-				"value": "tools",
-				"label": "tools"
-			},
-			{
-				"value": "",
-				"label": "none"
-			}
-		]
-	},
-	"check_ticket": {
-		"infer_ticket": true,
-		"confirm_ticket": true,
-		"add_to_title": true,
-		"append_hashtag": true,
-		"surround": "",
-		"title_position": "start"
-	},
-	"commit_title": {
-		"max_size": 70
-	},
-	"commit_body": {
-		"enable": true,
-		"required": false
-	},
-	"commit_footer": {
-		"enable": true,
-		"initial_value": [],
-		"options": ["closes", "trailer", "breaking-change", "deprecated", "custom"]
-	},
-	"breaking_change": {
-		"add_exclamation_to_title": true
-	},
-	"confirm_commit": true,
-	"print_commit_output": true,
-	"branch_pre_commands": [],
-	"branch_post_commands": [],
-	"worktree_pre_commands": [],
-	"worktree_post_commands": [],
-	"branch_user": {
-		"enable": true,
-		"required": false,
-		"separator": "/"
-	},
-	"branch_type": {
-		"enable": true,
-		"separator": "/"
-	},
-	"branch_version": {
-		"enable": false,
-		"required": false,
-		"separator": "/"
-	},
-	"branch_ticket": {
-		"enable": true,
-		"required": false,
-		"separator": "-"
-	},
-	"branch_description": {
-		"max_length": 70,
-		"separator": ""
-	},
-	"branch_action_default": "branch",
-	"branch_order": ["user", "version", "type", "ticket", "description"],
-	"enable_worktrees": true,
-	"overrides": {}
+  "check_status": true,
+  "commit_type": {
+    "enable": true,
+    "initial_value": "feat",
+    "infer_type_from_branch": true,
+    "append_emoji_to_label": false,
+    "append_emoji_to_commit": false,
+    "options": [
+      {
+        "value": "feat",
+        "label": "feat",
+        "hint": "A new feature",
+        "emoji": "✨",
+        "trailer": "Changelog: feature"
+      },
+      {
+        "value": "fix",
+        "label": "fix",
+        "hint": "A bug fix",
+        "emoji": "🐛",
+        "trailer": "Changelog: fix"
+      },
+      {
+        "value": "docs",
+        "label": "docs",
+        "hint": "Documentation only changes",
+        "emoji": "📚",
+        "trailer": "Changelog: documentation"
+      },
+      {
+        "value": "refactor",
+        "label": "refactor",
+        "hint": "A code change that neither fixes a bug nor adds a feature",
+        "emoji": "🔨",
+        "trailer": "Changelog: refactor"
+      },
+      {
+        "value": "perf",
+        "label": "perf",
+        "hint": "A code change that improves performance",
+        "emoji": "🚀",
+        "trailer": "Changelog: performance"
+      },
+      {
+        "value": "test",
+        "label": "test",
+        "hint": "Adding missing tests or correcting existing tests",
+        "emoji": "🚨",
+        "trailer": "Changelog: test"
+      },
+      {
+        "value": "build",
+        "label": "build",
+        "hint": "Changes that affect the build system or external dependencies",
+        "emoji": "🚧",
+        "trailer": "Changelog: build"
+      },
+      {
+        "value": "ci",
+        "label": "ci",
+        "hint": "Changes to our CI configuration files and scripts",
+        "emoji": "🤖",
+        "trailer": "Changelog: ci"
+      },
+      {
+        "value": "tool",
+        "label": "tool",
+        "hint": "Changes to tooling",
+        "emoji": "🔧",
+        "trailer": "Changelog: tool"
+      },
+      {
+        "value": "chore",
+        "label": "chore",
+        "hint": "Other changes that do not modify src or test files",
+        "emoji": "🧹",
+        "trailer": "Changelog: chore"
+      },
+      {
+        "value": "",
+        "label": "none"
+      }
+    ]
+  },
+  "commit_scope": {
+    "enable": true,
+    "custom_scope": false,
+    "initial_value": "website",
+    "options": [
+      {
+        "value": "website",
+        "label": "website"
+      },
+      {
+        "value": "tools",
+        "label": "tools"
+      },
+      {
+        "value": "",
+        "label": "none"
+      }
+    ]
+  },
+  "check_ticket": {
+    "infer_ticket": true,
+    "confirm_ticket": true,
+    "add_to_title": true,
+    "append_hashtag": true,
+    "surround": "",
+    "title_position": "start"
+  },
+  "commit_title": {
+    "max_size": 70
+  },
+  "commit_body": {
+    "enable": true,
+    "required": false
+  },
+  "commit_footer": {
+    "enable": true,
+    "initial_value": [],
+    "options": ["closes", "trailer", "breaking-change", "deprecated", "custom"]
+  },
+  "breaking_change": {
+    "add_exclamation_to_title": true
+  },
+  "confirm_commit": true,
+  "print_commit_output": true,
+  "branch_pre_commands": [],
+  "branch_post_commands": [],
+  "worktree_pre_commands": [],
+  "worktree_post_commands": [],
+  "branch_user": {
+    "enable": true,
+    "required": false,
+    "separator": "/"
+  },
+  "branch_type": {
+    "enable": true,
+    "separator": "/"
+  },
+  "branch_version": {
+    "enable": false,
+    "required": false,
+    "separator": "/"
+  },
+  "branch_ticket": {
+    "enable": true,
+    "required": false,
+    "separator": "-"
+  },
+  "branch_description": {
+    "max_length": 70,
+    "separator": ""
+  },
+  "branch_action_default": "branch",
+  "branch_order": ["user", "version", "type", "ticket", "description"],
+  "enable_worktrees": true,
+  "overrides": {}
 }

--- a/.better-commits.json
+++ b/.better-commits.json
@@ -106,7 +106,7 @@
 		"infer_ticket": true,
 		"confirm_ticket": true,
 		"add_to_title": true,
-		"append_hashtag": false,
+		"append_hashtag": true,
 		"surround": "",
 		"title_position": "start"
 	},

--- a/README.md
+++ b/README.md
@@ -1,4 +1,34 @@
-# Astro Starter Kit: Minimal
+# YoungVision Website - Built with Astro
+
+[![Built with Astro](https://astro.badg.es/v2/built-with-astro/small.svg)](https://astro.build)
+
+## 🏃 Get Started
+
+### 📦 Requirements
+
+- Node.js v16 or higher
+- [pnpm](https://pnpm.io)
+- [better-commits](https://github.com/Everduin94/better-commits)
+
+### 📦 Install
+
+```bash
+pnpm install
+```
+
+### 📦 Working on tasks
+
+Choose an issue and then create a branch with
+
+```bash
+better-branch
+```
+
+After you've done some work on it commit your changes with
+
+```bash
+better-commits
+```
 
 ## 🚀 Project Structure
 


### PR DESCRIPTION
Closes #37 

This actually does nothing itself. Developers have to install `better-commits` themselves. I've documented that in the README