### PR TITLE
feat(app): #38 update posts from instagram API

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,5 +7,13 @@ import tailwind from '@astrojs/tailwind';
 export default defineConfig({
   server: ({ command }) => ({ port: command === 'dev' ? 5173 : 4321 }),
   trailingSlash: 'never',
+  image: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**.cdninstagram.com',
+      },
+    ],
+  },
   integrations: [svelte(), tailwind()],
 });

--- a/src/components/index/Instagram.astro
+++ b/src/components/index/Instagram.astro
@@ -4,7 +4,7 @@ import ArrowRight from '@assets/icons/ArrowRight.svelte';
 
 import { getRecentPhotos } from '@data/instagram';
 
-const images = await getRecentPhotos();
+const images = await getRecentPhotos(5);
 ---
 
 <section class="w-full pb-32 pt-12 lg:px-6">

--- a/src/components/index/Instagram.astro
+++ b/src/components/index/Instagram.astro
@@ -3,7 +3,6 @@ import ArrowLeft from '@assets/icons/ArrowLeft.svelte';
 import ArrowRight from '@assets/icons/ArrowRight.svelte';
 
 import { getRecentPhotos } from '@data/instagram';
-// TODO: get from Instagram API
 
 const images = await getRecentPhotos();
 ---
@@ -21,6 +20,7 @@ const images = await getRecentPhotos();
           <a href={image.link} target="_blank" rel="noopener">
             <div class="h-52 w-52 shrink-0 ">
               <img
+                sizes="13rem"
                 class="object-cover"
                 srcset={image.src.srcSet.attribute}
                 {...image.src.attributes}

--- a/src/data/instagram.ts
+++ b/src/data/instagram.ts
@@ -35,9 +35,9 @@ type InstagramAPINode = {
   };
 };
 
-export async function getRecentPhotos(): Promise<InstagramPost[]> {
+export async function getRecentPhotos(count: number): Promise<InstagramPost[]> {
   if (process.env.PLAYWRIGHT_TEST === 'true') {
-    return [
+    const fakePosts = [
       {
         src: await getPhoto(firstPost),
         alt: 'First Post',
@@ -65,9 +65,13 @@ export async function getRecentPhotos(): Promise<InstagramPost[]> {
         link: 'https://www.instagram.com/youngvision_ev/',
       },
     ];
+    // Just repeat fake posts to get the desired count
+    return Array(count)
+      .fill(null)
+      .map((_, i) => fakePosts[i % fakePosts.length]);
   }
   const { data } = await fetch(
-    'https://www.instagram.com/graphql/query/?query_id=17888483320059182&variables={%22id%22:%223938579639%22,%22first%22:5,%22after%22:null}',
+    `https://www.instagram.com/graphql/query/?query_id=17888483320059182&variables={%22id%22:%223938579639%22,%22first%22:${count},%22after%22:null}`,
     {
       method: 'GET',
       headers: {

--- a/src/data/instagram.ts
+++ b/src/data/instagram.ts
@@ -8,7 +8,7 @@ import secondPost from '@assets/instagram/second-post.png';
 import thirdPost from '@assets/instagram/third-post.png';
 
 async function getPhoto(src: string | ImageMetadata) {
-  return getImage({ src, widths: [96, 192, 256, 512], inferSize: true });
+  return getImage({ src, width: 208, height: 208, densities: [1, 1.5, 2] });
 }
 
 type InstagramPost = {

--- a/src/data/instagram.ts
+++ b/src/data/instagram.ts
@@ -1,6 +1,13 @@
+import type { ImageMetadata } from 'astro';
 import { getImage } from 'astro:assets';
 
-async function getPhoto(src: string) {
+import fifthPost from '@assets/instagram/fifth-post.png';
+import firstPost from '@assets/instagram/first-post.png';
+import fourthPost from '@assets/instagram/fourth-post.jpeg';
+import secondPost from '@assets/instagram/second-post.png';
+import thirdPost from '@assets/instagram/third-post.png';
+
+async function getPhoto(src: string | ImageMetadata) {
   return getImage({ src, widths: [96, 192, 256, 512], inferSize: true });
 }
 
@@ -29,6 +36,36 @@ type InstagramAPINode = {
 };
 
 export async function getRecentPhotos(): Promise<InstagramPost[]> {
+  if (process.env.PLAYWRIGHT_TEST === 'true') {
+    return [
+      {
+        src: await getPhoto(firstPost),
+        alt: 'First Post',
+        link: 'https://www.instagram.com/youngvision_ev/',
+      },
+      {
+        src: await getPhoto(secondPost),
+        alt: 'Second Post',
+        link: 'https://www.instagram.com/youngvision_ev/',
+      },
+      {
+        src: await getPhoto(thirdPost),
+        alt: 'Third Post',
+        link: 'https://www.instagram.com/youngvision_ev/',
+      },
+
+      {
+        src: await getPhoto(fourthPost),
+        alt: 'Fourth Post',
+        link: 'https://www.instagram.com/youngvision_ev/',
+      },
+      {
+        src: await getPhoto(fifthPost),
+        alt: 'Fifth Post',
+        link: 'https://www.instagram.com/youngvision_ev/',
+      },
+    ];
+  }
   const { data } = await fetch(
     'https://www.instagram.com/graphql/query/?query_id=17888483320059182&variables={%22id%22:%223938579639%22,%22first%22:5,%22after%22:null}',
     {

--- a/src/data/instagram.ts
+++ b/src/data/instagram.ts
@@ -1,14 +1,7 @@
-import type { ImageMetadata } from 'astro';
 import { getImage } from 'astro:assets';
 
-import fifthPost from '@assets/instagram/fifth-post.png';
-import firstPost from '@assets/instagram/first-post.png';
-import fourthPost from '@assets/instagram/fourth-post.jpeg';
-import secondPost from '@assets/instagram/second-post.png';
-import thirdPost from '@assets/instagram/third-post.png';
-
-async function getPhoto(src: ImageMetadata) {
-  return getImage({ src, widths: [96, 192, 256, 512] });
+async function getPhoto(src: string) {
+  return getImage({ src, widths: [96, 192, 256, 512], inferSize: true });
 }
 
 type InstagramPost = {
@@ -17,32 +10,41 @@ type InstagramPost = {
   link: string;
 };
 
+type InstagramAPINode = {
+  node: {
+    display_url: string;
+    dimensions: {
+      height: number;
+      width: number;
+    };
+    edge_media_to_caption: {
+      edges: {
+        node: {
+          text: string;
+        };
+      }[];
+    };
+    shortcode: string;
+  };
+};
+
 export async function getRecentPhotos(): Promise<InstagramPost[]> {
-  return [
+  const { data } = await fetch(
+    'https://www.instagram.com/graphql/query/?query_id=17888483320059182&variables={%22id%22:%223938579639%22,%22first%22:5,%22after%22:null}',
     {
-      src: await getPhoto(firstPost),
-      alt: 'First Post',
-      link: 'https://www.instagram.com/youngvision_ev/',
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+      },
     },
-    {
-      src: await getPhoto(secondPost),
-      alt: 'Second Post',
-      link: 'https://www.instagram.com/youngvision_ev/',
-    },
-    {
-      src: await getPhoto(thirdPost),
-      alt: 'Third Post',
-      link: 'https://www.instagram.com/youngvision_ev/',
-    },
-    {
-      src: await getPhoto(fourthPost),
-      alt: 'Fourth Post',
-      link: 'https://www.instagram.com/youngvision_ev/',
-    },
-    {
-      src: await getPhoto(fifthPost),
-      alt: 'Fifth Post',
-      link: 'https://www.instagram.com/youngvision_ev/',
-    },
-  ];
+  ).then((res) => res.json());
+  const posts = data.user.edge_owner_to_timeline_media.edges as InstagramAPINode[];
+
+  return Promise.all(
+    posts.map(async ({ node: p }: InstagramAPINode) => ({
+      src: await getPhoto(p.display_url),
+      alt: p.edge_media_to_caption.edges[0].node.text!,
+      link: `https://instagram.com/p/${p.shortcode}`,
+    })),
+  );
 }


### PR DESCRIPTION
This might break at any time if instagram changes the query_id. But the alternative is setting up an OAuth app which I couldn't get to work and might not be worth the hassle (at the moment).

Closes: #38