### PR TITLE
feat(website): show event sponsors

### DIFF
--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -34,6 +34,7 @@ export interface EventPage {
   team: { name: string; job: string; bio: string; image: ImageWithAlt }[];
   registrationLink: string;
   timetable?: ImageWithAlt;
+  sponsorLogo?: ImageWithAlt;
 }
 
 export type ImageWithAlt = {
@@ -98,6 +99,7 @@ export async function getAllEvents(): Promise<EventPage[]> {
     ),
     heroImage: await getEventImage(event.heroImage?.value),
     timetable: await getEventImage(event.timetable?.value),
+    sponsorLogo: await getEventImage(event.sponsorLogo?.value),
   })) as Promise<EventPage>[];
   const result = await Promise.all(promises);
   return result;

--- a/src/data/payload-types.ts
+++ b/src/data/payload-types.ts
@@ -22,6 +22,7 @@ export interface Config {
  */
 export interface User {
   id: string;
+  admin?: boolean | null;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -93,8 +94,13 @@ export interface Event {
     relationTo: 'media';
     value: string | Media;
   } | null;
+  sponsorLogo?: {
+    relationTo: 'media';
+    value: string | Media;
+  } | null;
   updatedAt: string;
   createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -112,6 +118,8 @@ export interface Media {
   filesize?: number | null;
   width?: number | null;
   height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -211,6 +211,18 @@ const locationPictures = [
           href={event.registrationLink}
         />
       </div>
+      {
+        event.sponsorLogo && (
+          <div>
+            <h2 class="font-serif text-2xl font-bold lg:text-4xl">Förderung</h2>
+            <Image
+              src={event.sponsorLogo.src}
+              alt={event.sponsorLogo.alt}
+              class="mt-3 w-full max-w-md"
+            />
+          </div>
+        )
+      }
     </div>
   </div>
 </Layout>


### PR DESCRIPTION
Is required by Zukunftspaket for example. Quick dirty fix, should be turned into a better sponsor block in the future _(with sponsor name, description, logo, ...)_